### PR TITLE
symfony4 autowiring and route format and dependencies update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.1.3",
         "tweedegolf/prometheus-client": "^0.2",
-        "symfony/config": "~2.7|~3.0",
-        "symfony/dependency-injection": "~2.7|~3.0",
-        "symfony/http-kernel": "~2.7|~3.0"
+        "symfony/config": "~4.0",
+        "symfony/dependency-injection": "~4.0",
+        "symfony/http-kernel": "~4.0"
     }
 }

--- a/src/Controller/MetricsController.php
+++ b/src/Controller/MetricsController.php
@@ -10,15 +10,27 @@ use TweedeGolf\PrometheusClient\Format\TextFormatter;
 class MetricsController extends Controller
 {
     /**
+     * @var CollectorRegistry
+     */
+    protected $registry;
+
+    /**
+     * MetricsController constructor.
+     *
+     * @param CollectorRegistry $registry
+     */
+    public function __construct(CollectorRegistry $registry)
+    {
+        $this->registry = $registry;
+    }
+
+    /**
      * @return Response
      */
-    public function metricsAction()
+    public function metrics()
     {
-        $registry = $this->get(CollectorRegistry::class);
         $formatter = new TextFormatter();
-        $registry->getCounter('planviewer_metrics_hits')->inc();
-
-        return new Response($formatter->format($registry->collect()), 200, [
+        return new Response($formatter->format($this->registry->collect()), 200, [
             'Content-Type' => $formatter->getMimeType(),
         ]);
     }

--- a/src/Resources/config/routing.yml
+++ b/src/Resources/config/routing.yml
@@ -1,3 +1,3 @@
 tweede_golf_prometheus_metrics:
     path:     "%tweede_golf_prometheus.metrics_path%"
-    defaults: { _controller: TweedeGolfPrometheusBundle:Metrics:metrics }
+    defaults: { _controller: TweedeGolf\PrometheusBundle\Controller\MetricsController::metrics }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,3 +1,10 @@
 services:
+    _defaults:
+        autowire: true
+
     TweedeGolf\PrometheusClient\Storage\ApcuAdapter: ~
     TweedeGolf\PrometheusClient\Storage\ApcAdapter: ~
+
+    TweedeGolf\PrometheusBundle\Controller\:
+        resource: '../../Controller'
+        tags: ['controller.service_arguments']


### PR DESCRIPTION
This add SF4 support.

Note that it does not keep backward compatibility so you should make a new major release when you publish it to packagist.

Another note : I removed the planviewer_metrics_hits counter in the metric route as it forces the developer to implement this counter.
