### PR TITLE
Increase the minimum client version and update `composer.lock`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "tweedegolf/prometheus-client": "^0.3",
+        "tweedegolf/prometheus-client": "^0.4",
         "symfony/config": "~2.7|~3.0|~4.0|~5.0",
         "symfony/dependency-injection": "~2.7|~3.0|~4.0|~5.0",
         "symfony/framework-bundle": "~2.7|~3.0|~4.0|~5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e37ad5c0ae13432a6a9ed147caaaeb34",
+    "content-hash": "b5f329fdc5972f6d3804df4af8dc192e",
     "packages": [
         {
             "name": "psr/cache",
@@ -1645,20 +1645,26 @@
         },
         {
             "name": "tweedegolf/prometheus-client",
-            "version": "v0.3.0",
+            "version": "v0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tweedegolf/prometheus-client.git",
-                "reference": "573b2fa0f3138f83dd8434b0102192cf1ad0e050"
+                "reference": "f97fc95fc82c2d62d8553c75d0211514e5e1aaf3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tweedegolf/prometheus-client/zipball/573b2fa0f3138f83dd8434b0102192cf1ad0e050",
-                "reference": "573b2fa0f3138f83dd8434b0102192cf1ad0e050",
+                "url": "https://api.github.com/repos/tweedegolf/prometheus-client/zipball/f97fc95fc82c2d62d8553c75d0211514e5e1aaf3",
+                "reference": "f97fc95fc82c2d62d8553c75d0211514e5e1aaf3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "ext-json": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ext-redis": "*",
+                "phpunit/phpunit": "6.5.*|7.5.*",
+                "predis/predis": "^1.1"
             },
             "type": "library",
             "autoload": {
@@ -1677,7 +1683,11 @@
                 }
             ],
             "description": "A PHP Prometheus client library",
-            "time": "2018-12-07T13:37:17+00:00"
+            "support": {
+                "issues": "https://github.com/tweedegolf/prometheus-client/issues",
+                "source": "https://github.com/tweedegolf/prometheus-client/tree/v0.4.0"
+            },
+            "time": "2022-01-10T21:21:47+00:00"
         }
     ],
     "packages-dev": [],
@@ -1689,5 +1699,6 @@
     "platform": {
         "php": ">=7.1.3"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
Increase the minimum client version to apply the latest changes regarding the additional opcache = false check.

This explicit bump is required as the bundle commits the `composer.lock`.